### PR TITLE
added direct exchange for sending mesasges to a specified routing key…

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,9 @@
     "basic:consume": "node src/basic/consumer",
     "broadcast:produce": "node src/pubSub/producer",
     "broadcast:consume": "node src/pubSub/consumer",
+    "directroute:consume:analytics": "node src/directRouting/analyticsConsumer",
+    "directroute:consume:payments": "node src/directRouting/paymentsConsumer",
+    "directroute:produce": "node src/directRouting/producer",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "keywords": [],

--- a/src/directRouting/analyticsConsumer.js
+++ b/src/directRouting/analyticsConsumer.js
@@ -1,0 +1,32 @@
+const {
+  getConnection,
+  ROUTING_EXCHANGE,
+  BOTH_ROUTING_KEY,
+  ANALYTICS_ONLY_KEY,
+} = require("../utils/connection");
+
+const consumer = async () => {
+  const conn = await getConnection();
+  const channel = await conn.createChannel();
+  await channel.assertExchange(ROUTING_EXCHANGE, "direct");
+  const { queue: randomQueueName } = await channel.assertQueue("", {
+    exclusive: true,
+  });
+
+  await channel.bindQueue(
+    randomQueueName,
+    ROUTING_EXCHANGE,
+    ANALYTICS_ONLY_KEY
+  );
+  await channel.bindQueue(randomQueueName, ROUTING_EXCHANGE, BOTH_ROUTING_KEY);
+
+  await channel.consume(
+    randomQueueName,
+    (msg) => {
+      console.log("mesasge in " + ANALYTICS_ONLY_KEY, msg?.content.toString());
+    },
+    { noAck: true }
+  );
+};
+
+consumer();

--- a/src/directRouting/paymentsConsumer.js
+++ b/src/directRouting/paymentsConsumer.js
@@ -1,0 +1,28 @@
+const {
+  getConnection,
+  ROUTING_EXCHANGE,
+  BOTH_ROUTING_KEY,
+  PAYMENTS_ONLY_KEY,
+} = require("../utils/connection");
+
+const consumer = async () => {
+  const conn = await getConnection();
+  const channel = await conn.createChannel();
+  await channel.assertExchange(ROUTING_EXCHANGE, "direct");
+  const { queue: randomQueueName } = await channel.assertQueue("", {
+    exclusive: true,
+  });
+
+  await channel.bindQueue(randomQueueName, ROUTING_EXCHANGE, PAYMENTS_ONLY_KEY);
+  await channel.bindQueue(randomQueueName, ROUTING_EXCHANGE, BOTH_ROUTING_KEY);
+
+  await channel.consume(
+    randomQueueName,
+    (msg) => {
+      console.log("mesasge in " + PAYMENTS_ONLY_KEY, msg?.content.toString());
+    },
+    { noAck: true }
+  );
+};
+
+consumer();

--- a/src/directRouting/producer.js
+++ b/src/directRouting/producer.js
@@ -1,0 +1,24 @@
+const {
+  getConnection,
+  ROUTING_EXCHANGE,
+  BOTH_ROUTING_KEY,
+  ANALYTICS_ONLY_KEY,
+} = require("../utils/connection");
+
+const produce = async () => {
+  try {
+    const conn = await getConnection();
+    const channel = await conn.createChannel();
+    await channel.assertExchange(ROUTING_EXCHANGE, "direct");
+    const message = "this message needs to be routed";
+    channel.publish(ROUTING_EXCHANGE, BOTH_ROUTING_KEY, Buffer.from(message));
+    console.log("message sent");
+
+    await channel.close();
+    await conn.close();
+  } catch (err) {
+    console.log("Err:", err);
+  }
+};
+
+produce();

--- a/src/utils/connection.js
+++ b/src/utils/connection.js
@@ -3,6 +3,10 @@ const amqplib = require("amqplib");
 
 const LETTERBOX_QUEUE = "letterbox";
 const PUB_SUB_EXCHANGE = "pubSub";
+const ROUTING_EXCHANGE = "routing";
+const BOTH_ROUTING_KEY = "both";
+const ANALYTICS_ONLY_KEY = "analyticsonly";
+const PAYMENTS_ONLY_KEY = "paymentsonly";
 
 const getConnection = async () => {
   try {
@@ -15,4 +19,35 @@ const getConnection = async () => {
   }
 };
 
-module.exports = { getConnection, LETTERBOX_QUEUE, PUB_SUB_EXCHANGE };
+const composeConnection = async (fn, closeConnection) => {
+  let conn;
+  try {
+    conn = await amqplib.connect(
+      `amqp://${process.env.RMQ_USER_NAME}:${process.env.RMQ_PASS}@${process.env.RMQ_HOST}:${process.env.RMQ_PORT}`
+    );
+  } catch (err) {
+    console.log("Connection Err:", err);
+  }
+
+  return async (...args) => {
+    try {
+      await fn(conn, ...args);
+      if (closeConnection) {
+        await conn.close();
+      }
+    } catch (err) {
+      console.log("Exception at outerlevel", err);
+    }
+  };
+};
+
+module.exports = {
+  getConnection,
+  LETTERBOX_QUEUE,
+  PUB_SUB_EXCHANGE,
+  composeConnection,
+  ROUTING_EXCHANGE,
+  BOTH_ROUTING_KEY,
+  ANALYTICS_ONLY_KEY,
+  PAYMENTS_ONLY_KEY
+};


### PR DESCRIPTION
- 2 consumers analytics and payments. they all listen on analytics routing key and payment routing key
- additionaly both of them listen to `both` routing key